### PR TITLE
Update baseline.py

### DIFF
--- a/apic_fabric_setup/baseline.py
+++ b/apic_fabric_setup/baseline.py
@@ -7,9 +7,14 @@ Requirements:
   - ACI Cobra 3.0-1k or higher
 """
 
-# Run startup_script.py
-import startup_script
+from startup_script import configure_apic
 
-# Run main() from create_snv_apps
-import create_snv_apps
-create_snv_apps.main()
+
+def main():
+    print("\n\nStarting the APIC setup...")
+    configure_apic()
+    print("APIC setup complete.\n\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Updating this and startup_script.py in the same dir, as they were no longer working. 

Error received was:

python3 baseline.py 
Baselining APIC Simulator for Learning Labs
Setting up Fabric Nodes
Traceback (most recent call last):
  File "/home/xxxxx/xxxxx/ACI/ACI_labs/aci-learning-labs-code-samples/apic_fabric_setup/baseline.py", line 11, in <module>
    import startup_script
  File "/home/xxxxx/xxxxx/ACI/ACI_labs/aci-learning-labs-code-samples/apic_fabric_setup/startup_script.py", line 43, in <module>
    md.commit(c)
  File "/home/xxxxx/.venv/acivenv/lib/python3.11/site-packages/cobra/mit/access.py", line 66, in commit
    return self._accessImpl.post(configObject)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xxxxx/.venv/acivenv/lib/python3.11/site-packages/cobra/internal/rest/accessimpl.py", line 182, in post
    return self.__parseError(rsp, CommitError, rsp.status_code)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xxxxx/.venv/acivenv/lib/python3.11/site-packages/cobra/internal/rest/accessimpl.py", line 240, in __parseError
    parseXMLError(rsp.text, errorClass, httpCode)
  File "/home/xxxxx/.venv/acivenv/lib/python3.11/site-packages/cobra/mit/xmlcodec.py", line 20, in parseXMLError
    raise errorClass(int(errorCode), errorStr, httpCode)
cobra.mit.request.CommitError: Create-only and naming props cannot be modified after creation, class=fabricNodeIdentP, prop=nodeId (acivenv)